### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,7 @@ Tags allow to replace node values according to match:
 Use your favorite package manager (I prefer yarn)
 
 ```bash
-yarn add -D nuxt-feedme
-
-pnpm add -D nuxt-feedme
-
-npm install --save-dev nuxt-feedme
+npx nuxi@latest module add nuxt-feedme
 ```
 
 2. Add `nuxt-feedme` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
